### PR TITLE
Adds a readme, presenting our coc

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ We hope, as a team we can iterate and improve continually.
 
 No changes are final until approved by the President of the Montréal-Python user group and versions in place for a given year will be clearly marked, the website contents on montrealpython.org will clearly state the revision of the documents posted.
 
-You can have access to our current code of conduct by clicking [here](https://github.com/mtlpy/code-of-conduct/blob/master/CodeOfConduct.rst).
+Follow this link to read the full text: [Montréal-Python code of conduct](https://github.com/mtlpy/code-of-conduct/blob/master/CodeOfConduct.rst)
 
 -- fr --
 
@@ -40,4 +40,4 @@ On espère, en tant qu'en tant qu'équipe on itérera et on s'améliora continue
 Aucun changement n'est final tant qu'il n'est pas approuvé par le/la président/e du groupe Montréal-Python et la version en cours pour
 une année donnée sera clairement indiquée. Le site web du groupe à l'url montréalpython.org indiquera clairement l'état de la révision et le code de conduite courant.
 
-Vous pouvez consulter le code de conduite courant en cliquant [ici](https://github.com/mtlpy/code-of-conduct/blob/master/CodeDeConduite.rst).
+Suivez le lien pour lire le texte complet: [code de conduite de Montréal-Python](https://github.com/mtlpy/code-of-conduct/blob/master/CodeDeConduite.rst).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+Montréal-Python Code of Conduct
+===============================
+
+Presentation
+------------
+
+This is a "fork" of the PSF code of conduct and this README was inspired by the one of the PyCon code of conduct.
+
+Thank you to Adria Richards and many others with the Python Software Foundation and Python community for recommending that we publicly discuss and version control these documents so changes can be suggested, wording corrected and we can continue to iterate, as a community on these policies and procedures.
+
+Thanks to the members of the Montréal-Python user group for taking time to translate the code of conduct of the PSF in French.
+
+Montréal-Python and the community as a whole are still very much in a learning process, the group is 10 years old and still evolving daily. Each year we see massive improvements (such as the code of conduct).
+
+We hope, as a team we can iterate and improve continually.
+
+No changes are final until approved by the President of the Montréal-Python user group and versions in place for a given year will be clearly marked, the website contents on montrealpython.org will clearly state the revision of the documents posted.
+
+You can have access to our current code of conduct by clicking [here](https://github.com/mtlpy/code-of-conduct/blob/master/CodeOfConduct.rst).
+
+-- fr --
+
+Code de conduite de Montréal-Python
+===================================
+
+Présentation
+------------
+
+Ceci est un "fork" du code de conduite de la Python Software Foundation et ce README a été inspiré par celui du code de conduite de PyCon.
+
+Merci à toi Adria Richards et à tous les autres qui, avec la Python Software Foundation et le communauté Python ont recommandés que l'on discute publiquement et qu'on versione ces documents afin que des changements puissent être suggérés, que la formulation puisse être corrigée et que l'on puisse itérer en tant que communauté autour de ces politiques et de ces procédures.
+
+Merci aussi au membres du groupe Montréal-Python qui ont donné de leur temps pour traduire le code de conduite de la PSF en Français.
+
+Montréal-Python et notre communauté entière est en processus d'apprentissage. Le groupe a 10 ans et évolue encore chaque jour.
+Chaque année, on peut se rendre compte d'amélioration constante (telle que le code de conduite).
+
+On espère, en tant qu'en tant qu'équipe on itérera et on s'améliora continuellement.
+
+Aucun changement n'est final tant qu'il n'est pas approuvé par le/la président/e du groupe Montréal-Python et la version en cours pour
+une année donnée sera clairement indiquée. Le site web du groupe à l'url montréalpython.org indiquera clairement l'état de la révision et le code de conduite courant.
+
+Vous pouvez consulter le code de conduite courant en cliquant [ici](https://github.com/mtlpy/code-of-conduct/blob/master/CodeDeConduite.rst).


### PR DESCRIPTION
Cette PR propose un README qui introduit et propose un code de conduite du groupe Montréal-Python, dans les deux langues: en français et en anglais.

La traduction avait été fait par des bénévoles du groupe mais malheureusement les crédits se perdent l'histoire de nos soirées de projet.

Si quelqu'un l'informations sur qui avait fait la traduction ça serait super de l"ajouter dans ce README